### PR TITLE
Add boolean flag to enable/disable json-streaming-log file rotation

### DIFF
--- a/scripts/main.bro
+++ b/scripts/main.bro
@@ -19,6 +19,10 @@ export {
 	## set separately since these logs are ephemeral and meant to be
 	## immediately carried off to some other storage and search system.
 	const JSONStreaming::rotation_interval = 15mins &redef;
+
+	## If you would like to disable rotation of the "JSON streaming" output log
+	## files entirely, set this to `F`.
+	const JSONStreaming::enable_log_rotation = T &redef;
 }
 
 type JsonStreamingExtension: record {
@@ -78,8 +82,12 @@ event bro_init() &priority=-1000
 				filt$path = "json_streaming_" + filt$path_func(stream, "", []);
 			
 			filt$writer = Log::WRITER_ASCII;
-			filt$postprocessor = rotate_logs;
-			filt$interv = rotation_interval;
+
+			if ( JSONStreaming::enable_log_rotation )
+				{
+				filt$postprocessor = rotate_logs;
+				filt$interv = rotation_interval;
+				}
 
 			filt$ext_func = add_json_streaming_log_extension;
 			filt$ext_prefix = "_";

--- a/scripts/main.bro
+++ b/scripts/main.bro
@@ -9,20 +9,20 @@ export {
 	## associated settings.
 	const JSONStreaming::disable_default_logs = F &redef;
 
-	## The number of extra files that Bro will leave laying around so that
-	## any process watching the inode can finish.  The files will be named
-	## with the following scheme: `json_streaming_<path>.<num>.log`.  So, the 
-	## first conn log would be named: `json_streaming_conn.1.log`.
-	const JSONStreaming::extra_files = 4 &redef;
-
-	## A rotation interval specifically for the JSON streaming logs.  This is 
-	## set separately since these logs are ephemeral and meant to be
-	## immediately carried off to some other storage and search system.
-	const JSONStreaming::rotation_interval = 15mins &redef;
-
 	## If you would like to disable rotation of the "JSON streaming" output log
 	## files entirely, set this to `F`.
 	const JSONStreaming::enable_log_rotation = T &redef;
+
+	## If rotation is enabled, this is the number of extra files that Bro will 
+	## leave laying around so that any process watching the inode can finish.  
+	## The files will be named with the following scheme: `json_streaming_<path>.<num>.log`.
+	## So, the first conn log would be named: `json_streaming_conn.1.log`.
+	const JSONStreaming::extra_files = 4 &redef;
+
+	## If rotation is enabled, this is the rotation interval specifically for the 
+	## JSON streaming logs.  This is set separately since these logs are ephemeral
+	## and meant to be immediately carried off to some other storage and search system.
+	const JSONStreaming::rotation_interval = 15mins &redef;
 }
 
 type JsonStreamingExtension: record {


### PR DESCRIPTION
Contrary to its originally-stated purpose of generating logs that "are ephemeral and meant to be immediately carried off to some other storage and search system", I've often wanted to use `json-streaming-logs` to generate large single files containing JSON events per `_path`. To achieve this I've always had to comment out the two lines in the script that configure log rotation. In this PR I've wrapped those two lines with a boolean flag that defaults to `T` to preserve the original behavior, but now I can achieve the alternative I seek at the command-line without changing the script, i.e.:

```
# zeek -r my.pcap local "JSONStreaming::enable_log_rotation=F"
```