### PR TITLE
add enabled_logs variable which can be redefed to limit the set of logs that gets JSON streaming logs created for it

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -27,6 +27,9 @@ export {
 	## JSON streaming logs.  This is set separately since these logs are ephemeral
 	## and meant to be immediately carried off to some other storage and search system.
 	const JSONStreaming::rotation_interval = 15mins &redef;
+
+	## Set of log names to get the json_streaming_ treatment. If empty, do all logs.
+	const JSONStreaming::enabled_logs: set[string] = set() &redef;
 }
 
 type JsonStreamingExtension: record {
@@ -87,6 +90,10 @@ event zeek_init() &priority=-5
 
 	for ( stream in Log::active_streams )
 		{
+		## Skip streams not in the enabled set (unless enabled_logs is empty)
+		if ( |JSONStreaming::enabled_logs| > 0 && !(stream in JSONStreaming::enabled_logs) )
+		    next;
+
 		for ( filter_name in Log::get_filter_names(stream) )
 			{
 			# This is here because we're modifying the list of filters right now...

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -91,7 +91,8 @@ event zeek_init() &priority=-5
 	for ( stream in Log::active_streams )
 		{
 		## Skip streams not in the enabled set (unless enabled_logs is empty)
-		if ( |JSONStreaming::enabled_logs| > 0 && !(stream in JSONStreaming::enabled_logs) )
+		local stream_name = Log::id_name(stream);
+		if ( |JSONStreaming::enabled_logs| > 0 && !(stream_name in JSONStreaming::enabled_logs) )
 		    next;
 
 		for ( filter_name in Log::get_filter_names(stream) )

--- a/testing/tests/logs-filtered.zeek
+++ b/testing/tests/logs-filtered.zeek
@@ -1,0 +1,10 @@
+# @TEST-DOC: Verifies that Zeek by default writes both the usual logs and the (filtered) json-streaming ones.
+# @TEST-EXEC: zeek -r $TRACES/http.pcap $PACKAGE %INPUT
+# @TEST-EXEC: for f in conn files http packet_filter; do test -f $f.log; done
+# @TEST-EXEC: for f in files http; do test -f json_streaming_$f.log; done
+# @TEST-EXEC: for f in conn packet_filter; do ! test -f json_streaming_$f.log; done
+
+# Filter the list of files
+redef JSONStreaming::enabled_logs = set("http","files");
+# Turn off log rotation handling because it only kicks in for some of the files:
+redef JSONStreaming::enable_log_rotation = F;

--- a/testing/tests/logs-filtered.zeek
+++ b/testing/tests/logs-filtered.zeek
@@ -5,6 +5,6 @@
 # @TEST-EXEC: for f in conn packet_filter; do ! test -f json_streaming_$f.log; done
 
 # Filter the list of files
-redef JSONStreaming::enabled_logs = set("http","files");
+redef JSONStreaming::enabled_logs = set(HTTP::LOG, Files::LOG);
 # Turn off log rotation handling because it only kicks in for some of the files:
 redef JSONStreaming::enable_log_rotation = F;


### PR DESCRIPTION
```
# Filter the list of files
redef JSONStreaming::enabled_logs = set("http","files");
```

This PR adds the ability to do the above. By default `enabled_logs` is an empty set, meaning "do all of the logs" (the current default behavior). But by setting `enabled_logs` to a set containing one or more log names (e.g., `conn`, `http`, `dns,` `files`, etc.) then only those `json_streaming_` logs get created. The rest of the logic (for rotating, etc.) is untouched.

I also added `testing/tests/logs-filtered.zeek` to verify.